### PR TITLE
NO JIRA. Correction in rule about payload manifests.

### DIFF
--- a/versions/0.0.0.md
+++ b/versions/0.0.0.md
@@ -191,7 +191,7 @@ Requirements
    its value SHOULD be the user name of an existing EASY user account.
 
 #### 1.3 Manifests
-1. (a) The bag MUST have a SHA-1 payload manifest. (b) It should have entries for all the payload files.
+1. (a) The bag MUST have a SHA-1 payload manifest. (b) It MUST have entries for all the payload files.
 
 2. The bag MAY have other payload manifests and tag manifests.
 


### PR DESCRIPTION
All payload files must have a SHA-1 checksum. This is already enforced by `dans-validate-dans-bag`.