### PR TITLE
NO-JIRA fix easy-bag-store links

### DIFF
--- a/versions/0.0.0.md
+++ b/versions/0.0.0.md
@@ -344,7 +344,7 @@ References
 * [XML Schema] - constraint language for specifying types of XML documents
 
 [AIP]: https://en.wikipedia.org/wiki/Open_Archival_Information_System#The_OAIS_environment_and_information_model
-[bag-store]: https://dans-knaw.github.io/easy-bag-store/03_definitions.html
+[bag-store]: https://dans-knaw.github.io/easy-bag-store/definitions
 [BagIt]: https://tools.ietf.org/html/draft-kunze-bagit
 [DANS administrative metadata]: https://easy.dans.knaw.nl/schemas/bag/metadata/amd/amd.xsd
 [DANS bag file metadata schema]: https://easy.dans.knaw.nl/schemas/bag/metadata/files/files.xsd
@@ -369,5 +369,5 @@ References
 [URIs of approved licenses]: ./0.0.0-licenses.txt
 [urn:uuid]: https://en.wikipedia.org/wiki/Universally_unique_identifier
 [UUID]: https://en.wikipedia.org/wiki/Universally_unique_identifier
-[virtually-valid]: https://dans-knaw.github.io/easy-bag-store/03_definitions.html#virtually-valid
+[virtually-valid]: https://dans-knaw.github.io/easy-bag-store/definitions/#virtually-valid
 [XML Schema]: https://www.w3.org/TR/xmlschema-1/


### PR DESCRIPTION
#### When applied it will
* change links to easy-bag-store's documentation that changed after migration from Jekyll to MkDocs.

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### related pull requests on github
repo                       | PR
-------------------------- | -----------------
easy-                      | [PR#](PRlink) 
