### PR TITLE
EASY-2689: Make SHA-1 manifest mandatory for AIP only

### DIFF
--- a/versions/0.0.0.md
+++ b/versions/0.0.0.md
@@ -191,7 +191,7 @@ Requirements
    its value SHOULD be the user name of an existing EASY user account.
 
 #### 1.3 Manifests
-1. (a) The bag MUST have a SHA-1 payload manifest. (b) It MUST have entries for all the payload files.
+1. **(AIP)** (a) The bag MUST have a SHA-1 payload manifest. (b) It MUST have entries for all the payload files.
 
 2. The bag MAY have other payload manifests and tag manifests.
 


### PR DESCRIPTION
Fixes EASY-2869


#### When applied it will
* Make rule about SHA-1 being mandatory AIP-only.

#### Where should the reviewer @DANS-KNAW/easy start?

#### Related PR
* [x] https://github.com/DANS-KNAW/easy-validate-dans-bag/pull/82
* [x] awaiting PR on `easy-ingest-flow` to be completed (EASY-2690, https://github.com/DANS-KNAW/easy-ingest-flow/pull/141)