### PR TITLE
EASY-2730: Allow metadata/license.txt file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.idea
 /*.iml
+.DS_Store

--- a/docs/versions/0.0.0.md
+++ b/docs/versions/0.0.0.md
@@ -199,7 +199,7 @@ Requirements
 1. The bag MUST have a tag-directory called `metadata` (one word, lowercase letters) directly under
    the bag base directory.
 
-2. The `metadata` directory MUST contain the files: (a) `metadata/dataset.xml` and (b) `metadata/files.xml`. It MAY contain the files `metadata/amd.xml` and `metadata/emd.xml`.
+2. The `metadata` directory MUST contain the files: (a) `metadata/dataset.xml` and (b) `metadata/files.xml`. It MAY contain the files `metadata/amd.xml`, `metadata/emd.xml` or `metadata/license.txt`.
 
 3. The `metadata` directory MAY contain a directory `depositor-info` in which the following files MAY be present `metadata/depositor-info/agreements.xml` with information about agreements between the depositor and DANS. 
    Among other things it specifies the existence of personal data within the files in `data`.


### PR DESCRIPTION
fixes EASY-2730

#### When applied it will
*  Allow metadata/license.txt file

#### Where should the reviewer @DANS-KNAW/easy start?

#### related pull requests on github
repo                       | PR
-------------------------- | -----------------
easy-validate-dans-bag                      | [PR#85](https://github.com/DANS-KNAW/easy-validate-dans-bag/pull/85) 
