### PR TITLE
EASY-2748: Replace DOI with urn:NBN as mandatory identifier

### DIFF
--- a/docs/versions/0.0.0.md
+++ b/docs/versions/0.0.0.md
@@ -151,8 +151,6 @@ other terms, they are printed in *italics*.
 * **revision**: a *DANS-bag* that has been successfully archived in the *DANS Data Vault*. It has a [UUID] identifier and
   a timestamp that records its place in the *bag-sequence*.
 
-* **sequence-DOI**: a *DOI* that references *a bag-sequence*. It resolves to the most recent revision of that *dataset*.
-
 * **SIP**: Submission Information Package, as defined in the [OAIS Reference Model]. See also [SIP].
 
 * **update-deposit**: a *deposit* that is intended to be added as a revision of an existing, archived *dataset*.
@@ -221,7 +219,7 @@ Requirements
    `xsi:type="dcterms:URI"`, then the element text MUST be one of the [URIs of approved licenses].
 
 3. **(AIP)** The file `metadata/dataset.xml` MUST contain at least one `dcterms:identifier` element with
-   an attribute `xsi:type="id-type:DOI"`. The text of this element MUST be a syntactically valid [DOI] identifier
+   an attribute `xsi:type="id-type:URN"`. The text of this element MUST be a syntactically valid [urn:NBN] identifier
    which SHOULD be resolvable.
 
 4. Any `dcx-dai:DAI` elements MUST contain a syntactically valid [Digital Author Identifier] (DAI) with a valid check digit.
@@ -340,6 +338,7 @@ References
 * [SIP] - Submission Information Package
 * [URIs of approved licenses] - licenses that may be used for datasets deposited in the DANS archive
 * [urn:uuid] - URN scheme for [UUID]s
+* [urn:NBN] - URN scheme for National Bibliographic Numbers
 * [UUID] - universally unique identifiers
 * [XML Schema] - constraint language for specifying types of XML documents
 
@@ -368,6 +367,7 @@ References
 [SIP]: https://en.wikipedia.org/wiki/Open_Archival_Information_System#The_OAIS_environment_and_information_model
 [URIs of approved licenses]: ./0.0.0-licenses.txt
 [urn:uuid]: https://en.wikipedia.org/wiki/Universally_unique_identifier
+[urn:NBN]: https://www.kb.nl/organisatie/onderzoek-expertise/informatie-infrastructuur-diensten-voor-bibliotheken/registration-agency-nbn
 [UUID]: https://en.wikipedia.org/wiki/Universally_unique_identifier
 [virtually-valid]: https://dans-knaw.github.io/easy-bag-store/definitions/#virtually-valid
 [XML Schema]: https://www.w3.org/TR/xmlschema-1/


### PR DESCRIPTION
accompanies EASY-2748

#### When applied it will
* Remove definition of sequence-DOI 
* Replace DOI with urn:NBN as mandatory identifier (rule 3.1.3)

#### Where should the reviewer @DANS-KNAW/easy start?

#### related pull requests on github
repo                       | PR
-------------------------- | -----------------
easy-validate-dans-bag                      | [PR#86](https://github.com/DANS-KNAW/easy-validate-dans-bag/pull/86) 
