### PR TITLE
EASY-2017. Clarifying rules for bag-sequences.

### DIFF
--- a/docs/versions/0.0.0.md
+++ b/docs/versions/0.0.0.md
@@ -291,10 +291,14 @@ Requirements
 ### 4 Bag sequence requirements
 1. **(AIP)** The bag MUST be [virtually-valid] in the context of the bag store it is stored in.
 
-2. If `bag-info.txt` contains the element `Is-Version-Of` the UUID in its value MUST be the bag-id of an existing, archived bag.
-   This bag SHOULD be the base revision for the dataset that is to be updated by the deposit. **(AIP)** The `EASY-User-Account` of the archived bag MUST be identical to the `EASY-User-Account` in this `bag-info.txt`.
+2. If `bag-info.txt` contains the element `Is-Version-Of` the UUID in its value MUST be the bag-id of an existing, archived bag. This bag SHOULD be the base revision for the dataset that is to 
+   be updated by the deposit. 
+   
+3. **(AIP)** The bags of a bag-sequence MUST be stored in the same bag-store. 
 
-3. The accessibility and visibility of a dataset file MUST NOT be set to more restrictive than in previous, active
+4. **(AIP)** The `EASY-User-Account` in `bag-info.txt`  MUST be identical in all the bags of a bag-sequence.
+
+5. The accessibility and visibility of a dataset file MUST NOT be set to more restrictive than in previous, active
    revisions.
 
    Explanation: the previous revisions are the other bags in the same bag-sequence with a value in their `bag-info.txt`'s  `Created`-element, that is


### PR DESCRIPTION
After discussion with @vesaakerman we came up with the following modifications of the text. 

#### When applied it will
* Split up some of the rules about bag sequence consistency making them more readable.
* Explicitly state that bags of a sequence must be stored in the same bag-store.


