### PR TITLE
EASY-2770: (part 1) locations of "original-ddm.xml", "original-files.xml"

### DIFF
--- a/docs/versions/0.0.0.md
+++ b/docs/versions/0.0.0.md
@@ -197,7 +197,7 @@ Requirements
 1. The bag MUST have a tag-directory called `metadata` (one word, lowercase letters) directly under
    the bag base directory.
 
-2. The `metadata` directory MUST contain the files: (a) `metadata/dataset.xml` and (b) `metadata/files.xml`. It MAY contain the files `metadata/amd.xml`, `metadata/emd.xml` or `metadata/license.txt`.
+2. The `metadata` directory MUST contain the files: (a) `metadata/dataset.xml` and (b) `metadata/files.xml`. It MAY contain the files `metadata/amd.xml`, `metadata/emd.xml`,  `metadata/original-dataset.xml`, `metadata/original-files.xml` or `metadata/license.txt`.
 
 3. The `metadata` directory MAY contain a directory `depositor-info` in which the following files MAY be present `metadata/depositor-info/agreements.xml` with information about agreements between the depositor and DANS. 
    Among other things it specifies the existence of personal data within the files in `data`.


### PR DESCRIPTION
EASY-2770: (part 1) locations of "original-ddm.xml", "original-files.….xml"

fixes EASY-

#### When applied it will
* 
* 
* 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### related pull requests on github
https://github.com/DANS-KNAW/easy-validate-dans-bag/pull/91
https://github.com/DANS-KNAW/easy-fedora2vault/pull/17
