### PR TITLE
EASY-2761: version number in bagit.txt

### DIFF
--- a/docs/versions/0.0.0.md
+++ b/docs/versions/0.0.0.md
@@ -167,7 +167,7 @@ Requirements
 ### 1 BagIt related
 
 #### 1.1 Validity
-1. **(SIP)** The bag MUST be `VALID` according to the BagIt 1.0 specifications.
+1. **(SIP)** The bag MUST be `VALID` according to the BagIt specifications.
 
 #### 1.2 `bag-info.txt`
 1. The bag MUST contain a `bag-info.txt` file.

--- a/docs/versions/0.0.0.md
+++ b/docs/versions/0.0.0.md
@@ -167,7 +167,7 @@ Requirements
 ### 1 BagIt related
 
 #### 1.1 Validity
-1. **(SIP)** The bag MUST be `VALID` according to the BagIt 0.97 specifications.
+1. **(SIP)** The bag MUST be `VALID` according to the BagIt 1.0 specifications.
 
 #### 1.2 `bag-info.txt`
 1. The bag MUST contain a `bag-info.txt` file.


### PR DESCRIPTION
fixes EASY-2761: version number in bagit.txt

#### When applied it will
* 
* 
* 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### related pull requests on github
...
