### PR TITLE
EASY-2770: Allow 'original' directory in 'metadata' dir

### DIFF
--- a/docs/versions/0.0.0.md
+++ b/docs/versions/0.0.0.md
@@ -205,7 +205,7 @@ Requirements
      * either `metadata/depositor-info/depositor-agreement.pdf` or `metadata/depositor-info/depositor-agreement.txt`;
      * `metadata/depositor-info/message-from-depositor.txt`.
   
-  (b) The `metadata` directory MAY contain a directory `original` containing a `dataset.xml` and a `files.xml`, representing the original deposit
+    (b) The `metadata` directory MAY contain a directory `original` containing a `dataset.xml` and a `files.xml`, representing the original deposit
 
 4. **(SIP)** The `metadata` directory MAY contain a file called `metadata/depositor-info/message-from-depositor.txt`.
 

--- a/docs/versions/0.0.0.md
+++ b/docs/versions/0.0.0.md
@@ -199,11 +199,13 @@ Requirements
 
 2. The `metadata` directory MUST contain the files: (a) `metadata/dataset.xml` and (b) `metadata/files.xml`. It MAY contain the files `metadata/amd.xml`, `metadata/emd.xml` or `metadata/license.txt`.
 
-3. The `metadata` directory MAY contain a directory `depositor-info` in which the following files MAY be present `metadata/depositor-info/agreements.xml` with information about agreements between the depositor and DANS. 
+3. (a) The `metadata` directory MAY contain a directory `depositor-info` in which the following files MAY be present `metadata/depositor-info/agreements.xml` with information about agreements between the depositor and DANS. 
    Among other things it specifies the existence of personal data within the files in `data`.
    Other files that MAY be present are: 
      * either `metadata/depositor-info/depositor-agreement.pdf` or `metadata/depositor-info/depositor-agreement.txt`;
      * `metadata/depositor-info/message-from-depositor.txt`.
+  
+  (b) The `metadata` directory MAY contain a directory `original` containing a `dataset.xml` and a `files.xml`, representing the original deposit
 
 4. **(SIP)** The `metadata` directory MAY contain a file called `metadata/depositor-info/message-from-depositor.txt`.
 


### PR DESCRIPTION
accompanies EASY-2770

#### When applied it will
* 
* 
* 

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### related pull requests on github
repo                       | PR
-------------------------- | -----------------
easy-                      | [PR#](PRlink) 
