### PR TITLE
EASY-2846: Add Rule 2.7 on original-filepaths.txt

### DIFF
--- a/docs/versions/0.0.0.md
+++ b/docs/versions/0.0.0.md
@@ -231,7 +231,7 @@ Requirements
    <!-- Skip if XSD is used -->
 
 4. Each `file` element MUST have a `filepath` attribute which contains the bag local path to the payload file described. 
-   When an `original-filepaths.txt` exists, rule 2.7.4 applies.
+   When an `original-filepaths.txt` exists, rule 2.7.2 applies.
    Directories and non-payload files MUST NOT be described by a `file` element. 
 
 5. There MUST NOT be more than one `file` element corresponding to a payload file and every payload file MUST be described

--- a/docs/versions/0.0.0.md
+++ b/docs/versions/0.0.0.md
@@ -180,6 +180,15 @@ Requirements
 
 6. Files in the `data` directory MUST NOT have filepaths that include the following characters: `/`, `:`, `*`, `?`, `"`, `<`, `>`, `|`, `;`, `#`.
 
+#### 2.7 `original-filepaths.txt`
+1. A DANS bag MAY contain a file `original-filepaths.txt` in the root of the bag
+   
+2. It MUST be a UTF-8 encoded text file and MUST be formatted as `<physical-bag-relative-path><whitespace><orignal-bag-relative-path>`
+   
+3. `<physical-bag-relative-path>` MUST NOT contain whitespace and MUST correspond one-on-one to an existing payload file
+   
+4.  All `filepath` attributes in the `file` elements in the `files.xml` MUST appear in the `original-filepaths.txt` as an `<orignal-bag-relative-path>`
+   
 ### 3 Metadata requirements
 
 #### 3.1 `metadata/dataset.xml`
@@ -222,8 +231,9 @@ Requirements
 3. The document element MUST contain zero or more `file` elements, and MUST NOT contain other elements.
    <!-- Skip if XSD is used -->
 
-4. Each `file` element MUST have a `filepath` attribute which contains the bag local path to the payload file described.
-   Directories and non-payload files MUST NOT be described by a `file` element.
+4. Each `file` element MUST have a `filepath` attribute which contains the bag local path to the payload file described. 
+   When an `original-filepaths.txt` exists, rule 2.7.4 applies.
+   Directories and non-payload files MUST NOT be described by a `file` element. 
 
 5. There MUST NOT be more than one `file` element corresponding to a payload file and every payload file MUST be described
    by a `file` element.

--- a/docs/versions/0.0.0.md
+++ b/docs/versions/0.0.0.md
@@ -181,13 +181,12 @@ Requirements
 6. Files in the `data` directory MUST NOT have filepaths that include the following characters: `/`, `:`, `*`, `?`, `"`, `<`, `>`, `|`, `;`, `#`.
 
 #### 2.7 `original-filepaths.txt`
-1. A DANS bag MAY contain a file `original-filepaths.txt` in the root of the bag
+1. A DANS bag MAY contain a file `original-filepaths.txt` in the root of the bag in UTF-8 encoding.
    
-2. It MUST be a UTF-8 encoded text file and MUST be formatted as `<physical-bag-relative-path><whitespace><orignal-bag-relative-path>`
-   
-3. `<physical-bag-relative-path>` MUST NOT contain whitespace and MUST correspond one-on-one to an existing payload file
-   
-4.  All `filepath` attributes in the `file` elements in the `files.xml` MUST appear in the `original-filepaths.txt` as an `<orignal-bag-relative-path>`
+2. It MUST be formatted as `<physical-bag-relative-path><whitespace><orignal-bag-relative-path>`. 
+   * `<physical-bag-relative-path>` MUST NOT contain whitespace. 
+   * `<physical-bag-relative-path>` MUST correspond one-on-one to an existing payload file.
+   * `<orignal-bag-relative-path>` MUST correspond one-on-oen to a `filepath` attribute in the `file` elements in the `files.xml`. 
    
 ### 3 Metadata requirements
 


### PR DESCRIPTION
Fixes EASY-2846

# Description of changes
* Add Rule 2.7 on original-filepaths.txt
* Add reference to 2.7.2 to Rule 3.2.4

# How to test


# Related PRs
* [ ] [easy-validate-dans-bag](https://github.com/DANS-KNAW/easy-validate-dans-bag/pull/108)

# Notify
@DANS-KNAW/easy
