### PR TITLE
EASY-2837: Allow EASY-User-Account property in SIPs

### DIFF
--- a/docs/versions/0.0.0.md
+++ b/docs/versions/0.0.0.md
@@ -151,7 +151,7 @@ Requirements
    
 5. The `bag-info.txt` file MAY contain at most one element called `Is-Version-Of` with a [urn:uuid]-value.
 
-6. The `bag-info.txt` file (a) MUST **(AIP)** or (b) MUST NOT **(SIP)** contain an entry called `EASY-User-Account`. If present,
+6. The `bag-info.txt` file (a) MUST **(AIP)** or (b) MAY **(SIP)** contain an entry called `EASY-User-Account`. If present,
    its value SHOULD be the user name of an existing EASY user account.
 
 #### 1.3 Manifests


### PR DESCRIPTION
Fixes EASY-2837

# Description of changes
The `bag-info.txt` file MAY contain an entry called `EASY-User-Account`

# How to test


# Related PRs
repo                       | PR                | note
-------------------------- | ----------------- | ----
easy-validate-dans-bag                      | [PR#109](https://github.com/DANS-KNAW/easy-validate-dans-bag/pull/109)     | 
easy-ingest-flow                     | [PR#152](https://github.com/DANS-KNAW/easy-ingest-flow/pull/152)     | 


# Notify
@DANS-KNAW/easy
