### PR TITLE
DD-1107. Move rule about prefix for dansOtherId to context rules

### DIFF
--- a/docs/versions/1.0.0.md
+++ b/docs/versions/1.0.0.md
@@ -279,7 +279,7 @@ Requirements
 4. If `bag-info.txt` contains the element `Is-Version-Of` there MUST be a dataset in the target Data Station with the
    following properties: (a) it has a `dansSwordToken` with the same value as `Is-Version-Of` (b) it has a `dansOtherId`
    with the same value as bag-info.txt's `Has-Organizational-Identifier` (or both are absent) (c) the user account in
-   `Data-Station-User-Account` is authorized to update this dataset <!-- i.e. is a swordupdater on the dataset --->
+   `Data-Station-User-Account` is authorized to update this dataset. <!-- i.e. is a swordupdater on the dataset --->
 
 References
 ----------

--- a/docs/versions/1.0.0.md
+++ b/docs/versions/1.0.0.md
@@ -166,11 +166,10 @@ Requirements
 4. The `bag-info.txt` file MAY contain at most one element called `Is-Version-Of` with a
    [urn:uuid]{:target=_blank}-value.
 
-5. (a) The `bag-info.txt` file MAY contain at most one element called `Has-Organizational-Identifier`. (b) The value of
-   this element MUST start with a client specific prefix agreed between the client and DANS. (c) If this
+5. (a) The `bag-info.txt` file MAY contain at most one element called `Has-Organizational-Identifier`. (b) If this
    `Has-Organizational-Identifier` is given, at most one `Has-Organizational-Identifier-Version` MAY be
-   present, containing the version number. See rule 4.2 (b) for the requirements if `Has-Organizational-Identifier` is
-   provided.
+   present, containing a version number. See rules 4.3 and 4.4(b) for context requirements if 
+   `Has-Organizational-Identifier` is provided.
 
 #### 1.3 Manifests
 
@@ -274,7 +273,10 @@ Requirements
 2. The `bag-info.txt` element `Data-Station-User-Account` MUST contain the user name of a Data Station
    account that is authorized to deposit the bag. <!-- i.e. is a swordcreator on the dataverse collection --->
 
-3. If `bag-info.txt` contains the element `Is-Version-Of` there MUST be a dataset in the target Data Station with the
+3. If `Has-Organizational-Identifier` is present in `bag-info.txt` then the value of this element MUST start with a
+   client specific prefix agreed between the client and DANS.
+
+4. If `bag-info.txt` contains the element `Is-Version-Of` there MUST be a dataset in the target Data Station with the
    following properties: (a) it has a `dansSwordToken` with the same value as `Is-Version-Of` (b) it has a `dansOtherId`
    with the same value as bag-info.txt's `Has-Organizational-Identifier` (or both are absent) (c) the user account in
    `Data-Station-User-Account` is authorized to update this dataset <!-- i.e. is a swordupdater on the dataset --->


### PR DESCRIPTION
Fixes DD-1107

# Description of changes
The "client specific prefix" can only be checked if it is clear who the client is, i.e. when `Data-Station-User-Account` is provided. The rule concerning this should therefore be moved to section 4.


# Notify
@DANS-KNAW/easy
