### PR TITLE
NO JIRA. Max embargo and supported licenses

### DIFF
--- a/docs/versions/1.0.0.md
+++ b/docs/versions/1.0.0.md
@@ -211,8 +211,8 @@ Requirements
 1. The file `metadata/dataset.xml` MUST adhere to [DANS dataset metadata schema]{:target=_blank}.
 
 2. The file `metadata/dataset.xml` MUST have at least one `dcterms:license` element as a child of the
-   `dcmiMetadata` element. This element MUST have the attribute `xsi:type="dcterms:URI"`, and the element text MUST be
-   one of the [URIs of approved licenses]{:target=_blank}.
+   `dcmiMetadata` element. Exactly one of these elements MUST have the attribute `xsi:type="dcterms:URI"` and have 
+   a URI as element text.
 
 3. The file `metadata/dataset.xml` MAY contain one or more `dcterms:identifier` elements with an
    attribute `xsi:type="id-type:DOI"`. The text of this element MUST be a syntactically valid [DOI]{:target=_blank}
@@ -283,6 +283,12 @@ Requirements
    following properties: (a) it has a `dansSwordToken` with the same value as `Is-Version-Of` (b) it has a `dansOtherId`
    with the same value as bag-info.txt's `Has-Organizational-Identifier` (or both are absent) (c) the user account in
    `Data-Station-User-Account` is authorized to update this dataset. <!-- i.e. is a swordupdater on the dataset --->
+
+5. The `metadata/dataset.xml` element `dcmiMetadata/dcterms:license` with attribute `xsi:type="dcterms:URI"` (see 3.1.2)
+   must be one of the licenses supported by the target Data Station.
+
+6. The date in `metadata/dataset.xml` element `profile/available` MUST NOT be further in the future than the limit set 
+   on embargoes in the target Data Station.
 
 References
 ----------


### PR DESCRIPTION
# Description of changes
* Changed rule 3.1.2 so that supported license list no longer needs to be maintained by the validator, but can instead be maintained only in Dataverse.
* Added two Data Station context level rules
   * rule 4.5 about supported licenses 
   * rule 4.6 about limit to embargo.


# Notify
@DANS-KNAW/easy
