### PR TITLE
NO JIRA. Drop rule 2.5

### DIFF
--- a/docs/versions/1.0.0.md
+++ b/docs/versions/1.0.0.md
@@ -177,9 +177,6 @@ Requirements
 
 4. The `metadata` directory MUST NOT contain any other files or directories.
 
-5. Files in the `data` directory MUST NOT have filepaths that include the following characters: `/`, `:`, `*`, `?`, `"`
-   , `<`, `>`, `|`, `;`, `#`.
-
 #### 2.6 `original-filepaths.txt`
 
 1. A DANS bag MAY contain a file `original-filepaths.txt` in the root of the bag in UTF-8 encoding.


### PR DESCRIPTION
# Description of changes
The rule can be dropped, because `dd-ingest-flow` will sanitize file and directory names.

# Notify
@DANS-KNAW/easy
@DANS-KNAW/dataversedans 
