### PR TITLE
Changes for Vault as a Service

### DIFF
--- a/docs/versions/1.0.0-migration-supplement.md
+++ b/docs/versions/1.0.0-migration-supplement.md
@@ -43,7 +43,7 @@ Requirements
 
 #### 3.1 `metadata/dataset.xml`
 
-* **3.1.10-MIGRATION**: Alternatively, `dcmiMetadata/dcx-dai:contributorDetails/dcx-dai:author`
+* **3.1.9-MIGRATION**: Alternatively, `dcmiMetadata/dcx-dai:contributorDetails/dcx-dai:author`
   and `dcmiMetadata/dcx-dai:contributorDetails/dcx-dai:organization` elements MAY specify the rights holder using the role `RightsHolder`.
 
 * **3.1.11**: Rule does not apply to migration.

--- a/docs/versions/1.0.0.md
+++ b/docs/versions/1.0.0.md
@@ -143,7 +143,7 @@ Requirements
 
 #### 1.3 Manifests
 
-1. If the bag has only one payload manifest it MUST NOT use the MD5 algorithm. However, tt MAY have an MD5 payload manifest in addition to other payload
+1. If the bag has only one payload manifest it MUST NOT use the MD5 algorithm. However, it MAY have an MD5 payload manifest in addition to other payload
    manifests.
 
 ### 2 Structural requirements
@@ -157,7 +157,8 @@ Requirements
 4. A DANS bag MAY contain a file `original-filepaths.txt` in the root of the bag in UTF-8 encoding. For the content requirements
    and purpose of this file, if it exists, see Section 3.3.
 
-5. The bag MUST NOT contain a payload file `data/original-metadata.zip`.
+<!-- todo: reformulate -->
+5. The bag MUST NOT contain a payload file `data/original-metadata.zip`. (Exception: the bag is deposited through the Vault Service.) 
 
 ### 3 Metadata requirements
 
@@ -168,7 +169,8 @@ Requirements
 2. The file `metadata/dataset.xml` MUST have at least one `dcterms:license` element as a child of the `dcmiMetadata` element. Exactly one of these elements MUST
    have the attribute `xsi:type="dcterms:URI"` and have a URI as element text. (See also rule 4.3.)
 
-3. The file `metadata/dataset.xml` MAY contain one or more `dcterms:identifier` elements with an attribute `xsi:type="id-type:DOI"`. The text of this element
+<!-- todo: reformulate -->
+3. The file `metadata/dataset.xml` MAY (for Vault Service: MUST) contain one or more `dcterms:identifier` elements with an attribute `xsi:type="id-type:DOI"`. The text of this element
    MUST be a syntactically valid [DOI]{:target=_blank} identifier which SHOULD be resolvable.
 
 4. Any `dcx-dai:<scheme>` elements (i.e. (a) DAI, (b) ISNI or (c) ORCID) MUST contain an identifier that complies with the syntaxis for the selected identifier
@@ -218,14 +220,15 @@ Requirements
 1. If `Has-Organizational-Identifier` is present in `bag-info.txt` then the value of this element MUST start with one of the approved prefixes. Each client will
    be assigned a unique prefix to use for this purpose.
 
-2. If `bag-info.txt` contains the element `Is-Version-Of` there MUST be a dataset in the target Data Station with the following properties: (a) it has
-   a `dansSwordToken` with the same value as `Is-Version-Of` (b) it has a `dansOtherId` with the same value as `bag-info.txt`'
+2. If `bag-info.txt` contains the element `Is-Version-Of` there MUST be a dataset in the target Data Station <!-- todo: reformulate for Vault Service --> with the following properties: (a) it has
+   a `dansSwordToken` with the same value as `Is-Version-Of` (b) it has a `dansOtherId` with the same value as `bag-info.txt`' (<!-- todo: not for Vault Service (Mendeley has a DOI per version) -->)
    s `Has-Organizational-Identifier` (or both are absent).
 
 3. The `metadata/dataset.xml` element `dcmiMetadata/dcterms:license` with attribute `xsi:type="dcterms:URI"` (see 3.1.2)  must be one of the licenses supported
-   by the target Data Station.
-
+   by the target Data Station. (<!-- todo: not for Vault Service -->)
+   
 4. The date in `metadata/dataset.xml` element `profile/available` MUST NOT be further in the future than the limit set on embargoes in the target Data Station.
+   <!-- todo: not for Vault Service (probably) -->
 
 References
 ----------

--- a/docs/versions/1.0.0.md
+++ b/docs/versions/1.0.0.md
@@ -18,7 +18,7 @@ Introduction
 This document specifies what constitutes an acceptable DANS bag. This includes all the requirements for a bag to be successfully processed by the ingest
 workflow.
 
-Version 1.0.0 covers the requirements used by the DANS Data Stations.
+Version 1.0.0 covers the requirements used by the DANS Data Stations and the Vault as a Service.
 
 (DANS internal note: DANS BagIt Profile is also being used in the migration from EASY to the Data Stations. Some rules are modified for migration deposits. See
 [Migration Supplement](1.0.0-migration-supplement.md).)
@@ -42,7 +42,8 @@ The requirements are subdivided into the following sections:
 * Structural requirements - requirements regarding the directories and files in the bag
 * Metadata requirements - requirements regarding the metadata files included in the bag
 * Data Station context requirements - requirements regarding the Data Station where the dataset is to be created or
-  modified
+  modified; these do not apply to the Vault as a Service
+* Vault as a Service context requirements - requirements that are only applicable to the Vault as a Service and not to the Data Stations 
 
 The sections are numbered and may have numbered subsections. The requirements themselves are stated as numbered rules.
 Rules may have parts that are labeled with letters: (a), (b), (c), etc. To uniquely identify a specific rule, use the
@@ -94,6 +95,9 @@ terms, they are printed in *italics*.
 
 * **DANS Data Station**: the publishing and archiving service of DANS for datasets
 
+* **Vault as a Service**: the service that allows customers to store datasets in the DANS Data Vault, without publishing
+  them in a Data Station
+
 * **DANS SWORD Service**: the DANS implementation of the [SWORDv2]{:target=_blank} protocol
 
 * **dataset**: an information package containing data and metadata published in a *DANS Data Station*. A dataset may
@@ -135,10 +139,10 @@ Requirements
    including the time zone and a millisecond precision time part. (c) The values in the `Created` timestamps SHOULD reflect the correct order of the versions.
 
 3. (a) The `bag-info.txt` file MAY contain at most one element called `Is-Version-Of` (b) with a
-   [urn:uuid]{:target=_blank}-value. See rule 4.2 for the context requirements if `Is-Version-Of` is provided.
+   [urn:uuid]{:target=_blank}-value. See rules 4.1 and 5.1 for the context requirements if `Is-Version-Of` is provided.
 
 4. (a) The `bag-info.txt` file MAY contain at most one element called `Has-Organizational-Identifier`. (b) If this `Has-Organizational-Identifier` is given,
-   at most one `Has-Organizational-Identifier-Version` MAY be present, containing a version number. (c) If `Has-Organizational-Identifier` is present 
+   at most one `Has-Organizational-Identifier-Version` MAY be present, containing a version number. (c) If `Has-Organizational-Identifier` is present
    then its value MUST start with one of the approved prefixes. Each client will be assigned a unique prefix to use for this purpose.
 
 #### 1.3 Manifests
@@ -164,7 +168,7 @@ Requirements
 1. The file `metadata/dataset.xml` MUST adhere to [DANS dataset metadata schema]{:target=_blank}.
 
 2. The file `metadata/dataset.xml` MUST have at least one `dcterms:license` element as a child of the `dcmiMetadata` element. Exactly one of these elements MUST
-   have the attribute `xsi:type="dcterms:URI"` and have a URI as element text. (See also rule 4.3.)
+   have the attribute `xsi:type="dcterms:URI"` and have a URI as element text. (See also rule 4.2.)
 
 3. Any `dcx-dai:<scheme>` elements (i.e. (a) DAI, (b) ISNI or (c) ORCID) MUST contain an identifier that complies with the syntaxis for the selected identifier
    scheme URI.
@@ -211,24 +215,23 @@ Requirements
 ### 4 Data Station context requirements
 
 1. If `bag-info.txt` contains the element `Is-Version-Of` there MUST be a dataset in the target Data Station with the following properties: (a) it has
-   a `dansSwordToken` with the same value as `Is-Version-Of` (b) it has a `dansOtherId` with the same value as `bag-info.txt`'s 
+   a `dansSwordToken` with the same value as `Is-Version-Of` (b) it has a `dansOtherId` with the same value as `bag-info.txt`'s
    `Has-Organizational-Identifier` (or both are absent).
 
 2. The `metadata/dataset.xml` element `dcmiMetadata/dcterms:license` with attribute `xsi:type="dcterms:URI"` (see 3.1.2)  must be one of the licenses supported
-   by the target Data Station. 
-   
+   by the target Data Station.
+
 3. The date in `metadata/dataset.xml` element `profile/available` MUST NOT be further in the future than the limit set on embargoes in the target Data Station.
 
 4. The bag MUST NOT contain a payload file `data/original-metadata.zip`.
 
 ### 5 Vault as a Service context requirements
 
-1. If `bag-info.txt` contains the element `Is-Version-Of` there MUST be a dataset in the Vault that has a `dansSwordToken` with the same value as 
+1. If `bag-info.txt` contains the element `Is-Version-Of` there MUST be a dataset in the Vault that has a `dansSwordToken` with the same value as
    `Is-Version-Of`.
 
 2. The file `metadata/dataset.xml` MUST contain exactly one `dcterms:identifier` element with an attribute `xsi:type="id-type:DOI"`. The text of
    this element MUST be a syntactically valid [DOI]{:target=_blank} identifier which SHOULD be resolvable.
-
 
 References
 ----------

--- a/docs/versions/1.0.0.md
+++ b/docs/versions/1.0.0.md
@@ -138,8 +138,8 @@ Requirements
    [urn:uuid]{:target=_blank}-value. See rule 4.2 for the context requirements if `Is-Version-Of` is provided.
 
 4. (a) The `bag-info.txt` file MAY contain at most one element called `Has-Organizational-Identifier`. (b) If this `Has-Organizational-Identifier` is given,
-   at most one `Has-Organizational-Identifier-Version` MAY be present, containing a version number. See rules 4.1 and 4.2(b) for context requirements if
-   `Has-Organizational-Identifier` is provided.
+   at most one `Has-Organizational-Identifier-Version` MAY be present, containing a version number. (c) If `Has-Organizational-Identifier` is present 
+   then its value MUST start with one of the approved prefixes. Each client will be assigned a unique prefix to use for this purpose.
 
 #### 1.3 Manifests
 
@@ -157,9 +157,6 @@ Requirements
 4. A DANS bag MAY contain a file `original-filepaths.txt` in the root of the bag in UTF-8 encoding. For the content requirements
    and purpose of this file, if it exists, see Section 3.3.
 
-<!-- todo: reformulate -->
-5. The bag MUST NOT contain a payload file `data/original-metadata.zip`. (Exception: the bag is deposited through the Vault Service.) 
-
 ### 3 Metadata requirements
 
 #### 3.1 `metadata/dataset.xml`
@@ -169,31 +166,27 @@ Requirements
 2. The file `metadata/dataset.xml` MUST have at least one `dcterms:license` element as a child of the `dcmiMetadata` element. Exactly one of these elements MUST
    have the attribute `xsi:type="dcterms:URI"` and have a URI as element text. (See also rule 4.3.)
 
-<!-- todo: reformulate -->
-3. The file `metadata/dataset.xml` MAY (for Vault Service: MUST) contain one or more `dcterms:identifier` elements with an attribute `xsi:type="id-type:DOI"`. The text of this element
-   MUST be a syntactically valid [DOI]{:target=_blank} identifier which SHOULD be resolvable.
-
-4. Any `dcx-dai:<scheme>` elements (i.e. (a) DAI, (b) ISNI or (c) ORCID) MUST contain an identifier that complies with the syntaxis for the selected identifier
+3. Any `dcx-dai:<scheme>` elements (i.e. (a) DAI, (b) ISNI or (c) ORCID) MUST contain an identifier that complies with the syntaxis for the selected identifier
    scheme URI.
 
-5. Any `gml:posList` elements nested in `gml:Polygon` elements:
+4. Any `gml:posList` elements nested in `gml:Polygon` elements:
 
     * MUST have an even number of values.
     * MUST have at least three different pairs of values, each of which describes one point.
     * MUST start and end with the same pair of values.
 
-6. If a `gml:MultiSurface` is used, all nested `gml:Polygon` MUST have the same `srsName` attribute.
+5. If a `gml:MultiSurface` is used, all nested `gml:Polygon` MUST have the same `srsName` attribute.
 
-7. Any `gml:Point/gml:pos` (pos nested in a Point), `gml:lowerCorner` and `gml:upperCorner` elements MUST have at least two values. These values MUST be
+6. Any `gml:Point/gml:pos` (pos nested in a Point), `gml:lowerCorner` and `gml:upperCorner` elements MUST have at least two values. These values MUST be
    numeric. In case the `srsName` specifies the [RD]{:target=_blank} scheme the values MUST be within the valid range.
 
-8. Any `dc:identifier` or `dcterms:identifier` element with attribute `xsi:type="id-type:ARCHIS-ZAAK-IDENTIFICATIE` MUST have a value of 10 or fewer characters.
+7. Any `dc:identifier` or `dcterms:identifier` element with attribute `xsi:type="id-type:ARCHIS-ZAAK-IDENTIFICATIE` MUST have a value of 10 or fewer characters.
 
-9. All URLs used in `metadata/dataset.xml` MUST be valid URLs with protocol `http` or `https`.
+8. All URLs used in `metadata/dataset.xml` MUST be valid URLs with protocol `http` or `https`.
 
-10. The file `metadata/dataset.xml` MUST have one or more rights holders, each in a `<dcterms:rightsHolder>` element as a child of the `dcmiMetadata` element.
+9. The file `metadata/dataset.xml` MUST have one or more rights holders, each in a `<dcterms:rightsHolder>` element as a child of the `dcmiMetadata` element.
 
-11. `dcx-dai:author` and `dcx-dai:organization` elements MUST NOT have the role `RightsHolder`.
+10. `dcx-dai:author` and `dcx-dai:organization` elements MUST NOT have the role `RightsHolder`.
 
 #### 3.2 `metadata/files.xml`
 
@@ -217,18 +210,25 @@ Requirements
 
 ### 4 Data Station context requirements
 
-1. If `Has-Organizational-Identifier` is present in `bag-info.txt` then the value of this element MUST start with one of the approved prefixes. Each client will
-   be assigned a unique prefix to use for this purpose.
+1. If `bag-info.txt` contains the element `Is-Version-Of` there MUST be a dataset in the target Data Station with the following properties: (a) it has
+   a `dansSwordToken` with the same value as `Is-Version-Of` (b) it has a `dansOtherId` with the same value as `bag-info.txt`'s 
+   `Has-Organizational-Identifier` (or both are absent).
 
-2. If `bag-info.txt` contains the element `Is-Version-Of` there MUST be a dataset in the target Data Station <!-- todo: reformulate for Vault Service --> with the following properties: (a) it has
-   a `dansSwordToken` with the same value as `Is-Version-Of` (b) it has a `dansOtherId` with the same value as `bag-info.txt`' (<!-- todo: not for Vault Service (Mendeley has a DOI per version) -->)
-   s `Has-Organizational-Identifier` (or both are absent).
-
-3. The `metadata/dataset.xml` element `dcmiMetadata/dcterms:license` with attribute `xsi:type="dcterms:URI"` (see 3.1.2)  must be one of the licenses supported
-   by the target Data Station. (<!-- todo: not for Vault Service -->)
+2. The `metadata/dataset.xml` element `dcmiMetadata/dcterms:license` with attribute `xsi:type="dcterms:URI"` (see 3.1.2)  must be one of the licenses supported
+   by the target Data Station. 
    
-4. The date in `metadata/dataset.xml` element `profile/available` MUST NOT be further in the future than the limit set on embargoes in the target Data Station.
-   <!-- todo: not for Vault Service (probably) -->
+3. The date in `metadata/dataset.xml` element `profile/available` MUST NOT be further in the future than the limit set on embargoes in the target Data Station.
+
+4. The bag MUST NOT contain a payload file `data/original-metadata.zip`.
+
+### 5 Vault as a Service context requirements
+
+1. If `bag-info.txt` contains the element `Is-Version-Of` there MUST be a dataset in the Vault that has a `dansSwordToken` with the same value as 
+   `Is-Version-Of`.
+
+2. The file `metadata/dataset.xml` MUST contain exactly one `dcterms:identifier` element with an attribute `xsi:type="id-type:DOI"`. The text of
+   this element MUST be a syntactically valid [DOI]{:target=_blank} identifier which SHOULD be resolvable.
+
 
 References
 ----------


### PR DESCRIPTION
NO JIRA

# Description of changes
* Split off an extra section for rules that are for Vault as a Service only.
* Rearranged the rules that are Data Station only so that they are all on the dedicated section.
* Renumbered rules and references to rules where necessary.


# Notify
@DANS-KNAW/easy
